### PR TITLE
./manage.py deleterevisions fails on Py3

### DIFF
--- a/src/reversion/management/commands/deleterevisions.py
+++ b/src/reversion/management/commands/deleterevisions.py
@@ -195,6 +195,10 @@ Examples:
 
         # Ask confirmation
         if confirmation:
+            try:
+                raw_input = raw_input
+            except NameError:
+                raw_input = input
             choice = raw_input("Are you sure you want to delete theses revisions? [y|N] ")
             if choice.lower() != "y":
                 print("Aborting revision deletion.")


### PR DESCRIPTION
Running delete revisions on Python 3.4.0 results in an error:

    choice = raw_input("Are you sure you want to delete theses revisions? [y|N] ")
NameError: name 'raw_input' is not defined